### PR TITLE
[FEATURE] List of DBs that will be ignored by default added.

### DIFF
--- a/config/prequel.php
+++ b/config/prequel.php
@@ -42,4 +42,16 @@ return [
         'USERNAME'   => env('DB_USERNAME', 'homestead'),
         'PASSWORD'   => env('DB_PASSWORD', 'secret'),
     ],
+
+    /*
+    |--------------------------------------------------------------------------
+    | Prequel Database Ignored
+    |--------------------------------------------------------------------------
+    |
+    | Databases that will be ignored during DB discoverinf
+    |
+    */
+    'ignoreDB' => [
+        '#mysql50#lost+found'
+    ],
 ];

--- a/config/prequel.php
+++ b/config/prequel.php
@@ -50,18 +50,23 @@ return [
     |
     | Databases and tables that will be ignored during database discovery
     |
+    | Example to ignore 'foo_database.users' and 'foo_database.password_resets':
+    |
+    |  'foo_database' => [
+    |         'users',
+    |         'password_resets'
+    |  ]
+    |
+    | Example to ignore the entire database using a wildcard
+    |
+    | 'foo_database' => [ '*' ]
+    |
     */
     'ignored' => [
-        'databases' => [
-            // Ignored databases
-            // 'information_schema',
-            // 'sys',
-            // 'performance_schema',
-            // 'mysql',
-            '#mysql50#lost+found',
-        ],
-        'tables' => [
-            // 'database' => ['table']
-        ]
+        // 'information_schema' => [ '*' ],
+        // 'sys' => [ '*' ],
+        // 'performance_schema' => [ '*' ] ,
+        // 'mysql'               => [ '*' ],
+        '#mysql50#lost+found' => [ '*' ]
     ],
 ];

--- a/config/prequel.php
+++ b/config/prequel.php
@@ -45,13 +45,23 @@ return [
 
     /*
     |--------------------------------------------------------------------------
-    | Prequel Ignore Database
+    | Prequel ignored databases and tables
     |--------------------------------------------------------------------------
     |
-    | Databases that will be ignored during DB discovering
+    | Databases and tables that will be ignored during database discovery
     |
     */
-    'ignoreDB' => [
-        '#mysql50#lost+found'
+    'ignored' => [
+        'databases' => [
+            // Ignored databases
+            // 'information_schema',
+            // 'sys',
+            // 'performance_schema',
+            // 'mysql',
+            '#mysql50#lost+found',
+        ],
+        'tables' => [
+            // 'database' => ['table']
+        ]
     ],
 ];

--- a/config/prequel.php
+++ b/config/prequel.php
@@ -45,10 +45,10 @@ return [
 
     /*
     |--------------------------------------------------------------------------
-    | Prequel Database Ignored
+    | Prequel Ignore Database
     |--------------------------------------------------------------------------
     |
-    | Databases that will be ignored during DB discoverinf
+    | Databases that will be ignored during DB discovering
     |
     */
     'ignoreDB' => [

--- a/src/Classes/Database/DatabaseTraverser.php
+++ b/src/Classes/Database/DatabaseTraverser.php
@@ -59,22 +59,26 @@ class DatabaseTraverser
         foreach ($this->getAllDatabases() as $value) {
             $databaseName = (object) $value['name'];
 
-            if (array_search($databaseName->official, config('prequel.ignored.databases')) === false) {
-                $collection[$databaseName->pretty] = [
-                    "official_name" => $databaseName->official,
-                    "pretty_name"   => $databaseName->pretty,
-                    "tables"        => $this->getTablesFromDB($databaseName->official),
-                ];
+            if (array_key_exists($databaseName->official, config('prequel.ignored'))) {
+                if (config('prequel.ignored.' . $databaseName->official)[0] === '*') {
+                    continue;
+                }
+            }
+
+            $collection[$databaseName->pretty] = [
+                "official_name" => $databaseName->official,
+                "pretty_name"   => $databaseName->pretty,
+                "tables"        => $this->getTablesFromDB($databaseName->official),
+            ];
     
-                foreach ($collection[$databaseName->pretty]['tables'] as $key => $table) {
-                    $tables_to_ignore = config('prequel.ignored.tables.'.$databaseName->official) ?? [];
-                    if (array_search($table['name']['official'], $tables_to_ignore) === false) {
-                        $tableName = $databaseName->official.'.'
-                        .$table['name']['official'];
-                        array_push($flatTableCollection, $tableName);
-                    } else {
-                        unset($collection[$databaseName->pretty]['tables'][$key]);
-                    }
+            foreach ($collection[$databaseName->pretty]['tables'] as $key => $table) {
+                $tables_to_ignore = config('prequel.ignored.'.$databaseName->official) ?? [];
+                if (array_search($table['name']['official'], $tables_to_ignore) === false) {
+                    $tableName = $databaseName->official.'.'
+                    .$table['name']['official'];
+                    array_push($flatTableCollection, $tableName);
+                } else {
+                    unset($collection[$databaseName->pretty]['tables'][$key]);
                 }
             }
         }

--- a/src/Classes/Database/DatabaseTraverser.php
+++ b/src/Classes/Database/DatabaseTraverser.php
@@ -30,15 +30,6 @@ class DatabaseTraverser
      * @var $databaseQueries
      */
     private $databaseQueries;
-
-    /**
-     * List of DBs that will be ignored
-     *
-     * @var array $ignore
-     */
-    private $ignore = [
-        '#mysql50#lost+found'
-    ];
     
     /**
      * DatabaseTraverser constructor.
@@ -68,7 +59,7 @@ class DatabaseTraverser
         foreach ($this->getAllDatabases() as $value) {
             $databaseName = (object) $value['name'];
 
-            if (array_search($databaseName->official, $this->ignore) === false) {
+            if (array_search($databaseName->official, config('prequel.ignoreDB')) === false) {
                 $collection[$databaseName->pretty] = [
                     "official_name" => $databaseName->official,
                     "pretty_name"   => $databaseName->pretty,

--- a/src/Classes/Database/DatabaseTraverser.php
+++ b/src/Classes/Database/DatabaseTraverser.php
@@ -59,18 +59,22 @@ class DatabaseTraverser
         foreach ($this->getAllDatabases() as $value) {
             $databaseName = (object) $value['name'];
 
-            if (array_search($databaseName->official, config('prequel.ignoreDB')) === false) {
+            if (array_search($databaseName->official, config('prequel.ignored.databases')) === false) {
                 $collection[$databaseName->pretty] = [
                     "official_name" => $databaseName->official,
                     "pretty_name"   => $databaseName->pretty,
                     "tables"        => $this->getTablesFromDB($databaseName->official),
                 ];
     
-                foreach ($collection[$databaseName->pretty]['tables'] as $table) {
-                    $tableName = $databaseName->official.'.'
+                foreach ($collection[$databaseName->pretty]['tables'] as $key => $table) {
+                    $tables_to_ignore = config('prequel.ignored.tables.'.$databaseName->official) ?? [];
+                    if (array_search($table['name']['official'], $tables_to_ignore) === false) {
+                        $tableName = $databaseName->official.'.'
                         .$table['name']['official'];
-    
-                    array_push($flatTableCollection, $tableName);
+                        array_push($flatTableCollection, $tableName);
+                    } else {
+                        unset($collection[$databaseName->pretty]['tables'][$key]);
+                    }
                 }
             }
         }

--- a/src/Classes/Database/DatabaseTraverser.php
+++ b/src/Classes/Database/DatabaseTraverser.php
@@ -32,6 +32,15 @@ class DatabaseTraverser
     private $databaseQueries;
 
     /**
+     * List of DBs that will be ignored
+     *
+     * @var array $ignore
+     */
+    private $ignore = [
+        '#mysql50#lost+found'
+    ];
+    
+    /**
      * DatabaseTraverser constructor.
      *
      * @param  string|null  $databaseType  Type of database see $_databaseConn
@@ -59,19 +68,20 @@ class DatabaseTraverser
         foreach ($this->getAllDatabases() as $value) {
             $databaseName = (object) $value['name'];
 
-            $collection[$databaseName->pretty] = [
-                "official_name" => $databaseName->official,
-                "pretty_name"   => $databaseName->pretty,
-                "tables"        => $this->getTablesFromDB($databaseName->official),
-            ];
-
-            foreach ($collection[$databaseName->pretty]['tables'] as $table) {
-                $tableName = $databaseName->official.'.'
-                    .$table['name']['official'];
-
-                array_push($flatTableCollection, $tableName);
+            if (array_search($databaseName->official, $this->ignore) === false) {
+                $collection[$databaseName->pretty] = [
+                    "official_name" => $databaseName->official,
+                    "pretty_name"   => $databaseName->pretty,
+                    "tables"        => $this->getTablesFromDB($databaseName->official),
+                ];
+    
+                foreach ($collection[$databaseName->pretty]['tables'] as $table) {
+                    $tableName = $databaseName->official.'.'
+                        .$table['name']['official'];
+    
+                    array_push($flatTableCollection, $tableName);
+                }
             }
-
         }
 
         ksort($collection);


### PR DESCRIPTION
### Prevent to load specific DBs. 

**Practical use**

- DB #mysql#lost+found is related with a bug in MySql. Is an invalid DB that will crash Prequel if it's present. I got this problem in laravel/homestead 8.5.
- Remove from the listing specific DBs. Good to have if you want to limit the scope of discovery of Prequel.

_Love the project, thanks for do this_