### PR TITLE
[FIX] Fix could not run in console

### DIFF
--- a/src/Classes/Database/DatabaseTraverser.php
+++ b/src/Classes/Database/DatabaseTraverser.php
@@ -30,7 +30,7 @@ class DatabaseTraverser
      * @var $databaseQueries
      */
     private $databaseQueries;
-    
+
     /**
      * DatabaseTraverser constructor.
      *
@@ -70,7 +70,7 @@ class DatabaseTraverser
                 "pretty_name"   => $databaseName->pretty,
                 "tables"        => $this->getTablesFromDB($databaseName->official),
             ];
-    
+
             foreach ($collection[$databaseName->pretty]['tables'] as $key => $table) {
                 $tables_to_ignore = config('prequel.ignored.'.$databaseName->official) ?? [];
                 if (array_search($table['name']['official'], $tables_to_ignore) === false) {

--- a/src/Http/Controllers/DatabaseController.php
+++ b/src/Http/Controllers/DatabaseController.php
@@ -50,9 +50,9 @@ class DatabaseController extends Controller
     /**
      * DatabaseActionController's constructor
      *
-     * @param  \Protoqol\Prequel\Http\Requests\PrequelDatabaseRequest  $request
+     * @param  \Illuminate\Http\Request|\Protoqol\Prequel\Http\Requests\PrequelDatabaseRequest  $request
      */
-    public function __construct(PrequelDatabaseRequest $request)
+    public function __construct($request)
     {
         $this->tableName     = $request->table;
         $this->databaseName  = $request->database;

--- a/src/PrequelServiceProvider.php
+++ b/src/PrequelServiceProvider.php
@@ -6,10 +6,11 @@ namespace Protoqol\Prequel;
 
 use Illuminate\Support\ServiceProvider;
 use Protoqol\Prequel\Classes\Database\DatabaseTraverser;
+use Protoqol\Prequel\Http\Controllers\DatabaseController;
+use Protoqol\Prequel\Http\Requests\PrequelDatabaseRequest;
 
 class PrequelServiceProvider extends ServiceProvider
 {
-
     /**
      * Register services.
      *
@@ -19,6 +20,14 @@ class PrequelServiceProvider extends ServiceProvider
     {
         $this->app->singleton(DatabaseTraverser::class, function () {
             return new DatabaseTraverser();
+        });
+
+        $this->app->singleton(DatabaseController::class, function ($app) {
+            if ($app->runningInConsole()) {
+                return new DatabaseController($app['request']);
+            }
+
+            return new DatabaseController($app[PrequelDatabaseRequest::class]);
         });
 
         $this->mergeConfigFrom(


### PR DESCRIPTION
#### Issue or feature explanation
In the console, there are two cases here.

1. **$request['table']** is null, so this code throws an Exception  be cause **Illuminate\Support\Str::singular()** only accepts string.

```php
$request['model'] = app(DatabaseTraverser::class)->getModel($request['table']);
```

2. If we add a first return of Protoqol\Prequel\Classes\DatabaseTraverser::getModel(), the application will throw an **"Illuminate\Validation\ValidationException  : The given data was invalid."** exception because "database", "table", "qualifiedName" parameters are required in **Protoqol\Prequel\Http\Requests\PrequelDatabaseRequest**.

#### Proposed solution/change
**Protoqol\Prequel\Http\Controllers\DatabaseController** constructor should accept the **Illuminate\Http\Request** in the console.
