### PR TITLE
[REFACTOR] Refactor getModel method

### DIFF
--- a/src/Classes/Database/DatabaseTraverser.php
+++ b/src/Classes/Database/DatabaseTraverser.php
@@ -123,19 +123,14 @@ class DatabaseTraverser
             return false;
         }
 
-        $model = 'App\\'.Str::studly(Str::singular($tableName));
-        if (class_exists($model)) {
-            return new $model;
-        }
+        $rootNamespace = app()->getNamespace();
+        $modelName = Str::studly(Str::singular($tableName));
 
-        $model = 'App\\Models\\'.Str::studly(Str::singular($tableName));
-        if (class_exists($model)) {
-            return new $model;
-        }
-
-        $model = 'App\\Model\\'.Str::studly(Str::singular($tableName));
-        if (class_exists($model)) {
-            return new $model;
+        foreach (['', 'Model\\', 'Models\\'] as $subNamespace) {
+            $model = $rootNamespace.$subNamespace.$modelName;
+            if (class_exists($model)) {
+                return new $model;
+            }
         }
 
         return false;


### PR DESCRIPTION
#### Issue or feature explanation
Laravel provides a command called "app:name" that helps to setup a customized root namespace instead instead of "App\". If someone change his/her root namespace, the **getModel** method will always return false.

#### Proposed solution/change
Get the root namespace via global method. Visit [here](https://github.com/laravel/framework/blob/d93227688008f6fdccba748444ebe1fda509e6df/src/Illuminate/Foundation/Application.php#L1173) for more details

```php
app()->getNamespace(); // Return the application root namespace whatever it is.
```
