### PR TITLE
[FIX] array_search mistake

### DIFF
--- a/src/Classes/Database/DatabaseTraverser.php
+++ b/src/Classes/Database/DatabaseTraverser.php
@@ -78,7 +78,7 @@ class DatabaseTraverser
             foreach ($collection[$databaseName->pretty]['tables'] as $key => $table) {
                 $tablesToIgnore = config('prequel.ignored.' . $databaseName->official) ?? [];
 
-                if (!array_search($table['name']['official'], $tablesToIgnore)) {
+                if (array_search($table['name']['official'], $tablesToIgnore) === false) {
                     array_push($flatTableCollection, $databaseName->official . '.' . $table['name']['official']);
                 } else {
                     unset($collection[$databaseName->pretty]['tables'][$key]);


### PR DESCRIPTION
#### PR Naming convention
FIX array_search mistake

#### Issue or feature explanation

array_search returns the first corresponding key，first element key is 0

#### Proposed solution/change

array_search(xxx)  === false
