### PR TITLE
[FIX] allows for use of php 7.1 and above

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,6 +1,7 @@
 language: php
 
 php:
+  - '7.1'
   - '7.2'
   - '7.3'
 env:

--- a/composer.json
+++ b/composer.json
@@ -11,7 +11,7 @@
   ],
   "minimum-stability": "beta",
   "require": {
-    "php": "^7.2",
+    "php": "^7.1 || ^7.2 || ^7.3",
     "laravel/framework": "^5.6"
   },
   "extra": {


### PR DESCRIPTION
[FIX] lowers required php version.

It seems like php 7.2 is not actually necessary for this package, so this drops the requirement down to 7.1

Changed the composer.json file, and add 7.1 back to the travis.yml file to ensure 7.1 is compatible.

I apologize, I haven't authored any packages, so I tried, but I'm not 100% sure on how to test this...