### PR TITLE
[FIX] fixed error in DatabaseController

### DIFF
--- a/src/Http/Controllers/DatabaseController.php
+++ b/src/Http/Controllers/DatabaseController.php
@@ -94,24 +94,6 @@
             ];
         }
 
-        if (config('database.connections.mysql.prefix')) {
-                config(['database.connections.mysql.prefix' => '']);
-                \Illuminate\Support\Facades\DB::purge();
-         }
-
-        // Usage of the DB facade should be avoided since this uses the default config, and not the prequel config. @TODO refactor
-        return [
-             "table"     => $this->qualifiedName,
-             "structure" => app(DatabaseTraverser::class)->getTableStructure(
-                 $this->databaseName,
-                 $this->tableName
-              ),
-             "data"      => DB::table($this->qualifiedName)->paginate(config('prequel.pagination')),
-        ];
-      
-        }
-
-
         /**
          * Find given value in given column with given operator.
          * @return mixed


### PR DESCRIPTION

#### PR Naming convention
[FIX] fixed error in DatabaseController

#### Issue or feature explanation
After the recent update, Prequel started showing errors when trying to access to the tables in any database.

#### Proposed solution/change
There was a chunk of code in the DatabaseController which seems to have been
pasted by mistake. Removing the code allows Prequel to work again.
