### PR TITLE
[FEATURE] Add support for Laravel 10

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -13,7 +13,7 @@
     "minimum-stability": "stable",
     "require": {
         "php": "^7.2.5|^8.0",
-        "laravel/framework": "^6.0|^7.0|^8.0|^9.0",
+        "laravel/framework": "^6.0|^7.0|^8.0|^9.0|^10",
         "ext-pdo": "*",
         "ext-json": "*"
     },


### PR DESCRIPTION
This PR allows this package to be installed on Laravel 10. I came accross this when trying to upgrade project from Laravel 9.x.

I am fully aware that Prequel 2.0 is on their way and should be ready in Q1 but it would be great to have Laravel 10 supported in the mean time.

Updates:
* Composer only
  * Added "^10" in "require" "laravel/framework"