### PR TITLE
Allow use in production

### DIFF
--- a/config/prequel.php
+++ b/config/prequel.php
@@ -14,6 +14,17 @@ return [
     */
 
     'enabled' => env('PREQUEL_ENABLED', true),
+    
+    /*
+    |--------------------------------------------------------------------------
+    | Prequel Production Master Switch : boolean
+    |--------------------------------------------------------------------------
+    |
+    | Manually enable Prequel in production. This setting should not be enabled!
+    |
+    */
+
+    'production_enabled' => env('PREQUEL_PRODUCTION_ENABLED', false),
 
 
     /*

--- a/src/Http/Middleware/Authorised.php
+++ b/src/Http/Middleware/Authorised.php
@@ -90,7 +90,7 @@ class Authorised
     {
         return (object)[
             "enabled"  =>
-                config("prequel.enabled") && config("app.env") !== "production",
+                config("prequel.enabled") && (config("app.env") !== "production" || config("prequel.production_enabled")),
             "detailed" => "Prequel has been disabled.",
         ];
     }


### PR DESCRIPTION
[FEATURE] Allow use in production

#### Issue or feature explanation

Providing the option to access Prequel in production will allow it to be used in system administrator dashboards for inexpensive DB operations. Setting it behind a warning and defaulting it to false will discourage its use for those who don't know exactly what they are doing.

#### Proposed solution/change

An additional boolean config setting (default: false) which can be enabled from .env was added to config/prequel.php. This variable is then checked in the Authorised middleware, allowing the configuration check to return true for enabled when the app environment is production and the production_enabled flag is enabled.

Love this package by the way, it's so much better than phpMyAdmin.
