### PR TITLE
Make MySQL the default connection type incase the project's connection type is different.

### DIFF
--- a/src/Connection/DatabaseConnector.php
+++ b/src/Connection/DatabaseConnector.php
@@ -26,6 +26,7 @@ class DatabaseConnector
                 $className = "PostgresConnection";
                 break;
             default:
+                $className = "MySqlConnection";
                 break;
         }
 


### PR DESCRIPTION
#### PR Naming convention

BUG: Fix to error Undefined variable $className

#### Issue or feature explanation

Currently, if the user doesn't use the Laravel's default connection types, an error is thrown `Undefined variable $className`
<img width="934" alt="image" src="https://github.com/Protoqol/Prequel/assets/2037708/4ed48007-2355-40bd-8e41-e71d35758e90">

This PR fixes Issue https://github.com/Protoqol/Prequel/issues/165


#### Proposed solution/change

Make MySQL the default connection in case the package can't find one of the default's connection types.
